### PR TITLE
Set up basic CI to run tests on every push

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -6,28 +6,32 @@ jobs:
   run-tests:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
+        python-version: ["3.9"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-    env:
-      OS: ${{ matrix.os }}
-      PYTHON: '3.9'
+
     steps:
     - name: Cancel Workflow Action
       uses: styfle/cancel-workflow-action@0.6.0
       with:
         access_token: ${{ github.token }}
+
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Set up Python
+
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
+        python-version: ${{ matrix.python-version }}
+
     - name: Install test requirements and extension
       shell: bash -l {0}
       run: |
-        pip install -r requirements.txt requirements-dev.txt
-        pip install -e .
+        python -m pip install -r requirements.txt requirements-dev.txt
+        python -m pip install -e .
+
     - name: Run tests
       shell: bash -l {0}
       run: |
-        pytest -rP  # env vars are set within certain tests
+        python -m pytest -rP  # env vars are set within certain tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,33 @@
+name: Run tests
+
+on: push
+
+jobs:
+  run-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: '3.9'
+    steps:
+    - name: Cancel Workflow Action
+      uses: styfle/cancel-workflow-action@0.6.0
+      with:
+        access_token: ${{ github.token }}
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install test requirements and extension
+      shell: bash -l {0}
+      run: |
+        pip install -r requirements.txt requirements-dev.txt
+        pip install -e .
+    - name: Run tests
+      shell: bash -l {0}
+      run: |
+        pytest -rP  # env vars are set within certain tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Install test requirements and extension
       run: |
-        python -m pip install -r requirements.txt requirements-dev.txt
+        python -m pip install -r requirements.txt -r requirements-dev.txt
         python -m pip install -e .
 
     - name: Run tests

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,12 +26,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install test requirements and extension
-      shell: bash -l {0}
       run: |
         python -m pip install -r requirements.txt requirements-dev.txt
         python -m pip install -e .
 
     - name: Run tests
-      shell: bash -l {0}
       run: |
         python -m pytest -rP  # env vars are set within certain tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# pinned dependencies to reproduce an entire development environment to run tests and check code style
+flake8==4.0.1
+pytest==6.2.5


### PR DESCRIPTION
Running tests on every push will help ensure that no breaking changes are accidentally introduced.