### PR TITLE
Quickfix: Make `speed_filter_on_above_threshold` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for ndx-franklab-novela
 
+## 0.2.2 (Unreleased)
+
+- Make `speed_filter_on_above_threshold` optional in `FrankLabOptogeneticEpochsTable`
+
 ## 0.2.1 (July 1, 2025)
 
 - Updated repository structure to use the latest NDX template.

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -413,6 +413,7 @@ def main():
                 neurodata_type_inc="VectorData",
                 doc=("If the speed filter was used, True if active when speed above threshold."),
                 dtype="bool",
+                quantity="?",
             ),
             NWBDatasetSpec(
                 name="stimulus_signal",


### PR DESCRIPTION
Fixes error where `speed_filter_on_above_threshold` was incorectly mandatory in the optogenetics epochs table