### PR TITLE
Fix usage of spatial_filter_region_node_coordinates_in_pixels in test

### DIFF
--- a/src/pynwb/tests/test_optogenetics.py
+++ b/src/pynwb/tests/test_optogenetics.py
@@ -65,7 +65,9 @@ class TestFrankLabOptogeneticsEpochsTable(TestCase):
             theta_filter_reference_ntrode=1,
             spatial_filter_on=True,
             spatial_filter_lockout_period_in_samples=10,
-            spatial_filter_region_node_coordinates_in_pixels=((260, 920), (800, 1050)),
+            # below is an example of a single rectangular spatial filter region defined by the pixel coordinates of the
+            # four corners
+            spatial_filter_region_node_coordinates_in_pixels=(((260, 920), (260, 800), (800, 1050), (800, 920)), ),
             spatial_filter_cameras=[camera1, camera2],
             spatial_filter_cameras_cm_per_pixel=[0.3, 0.18],
             ripple_filter_on=True,
@@ -113,7 +115,7 @@ class TestFrankLabOptogeneticsEpochsTable(TestCase):
             assert read_epochs[0, "spatial_filter_lockout_period_in_samples"] == 10
             assert np.array_equal(
                 read_epochs[0, "spatial_filter_region_node_coordinates_in_pixels"],
-                np.array([[260, 920], [800, 1050]]),
+                np.array((((260, 920), (260, 800), (800, 1050), (800, 920)), )),
             )
             assert read_epochs[0, "spatial_filter_cameras"] == [read_camera1, read_camera2]
             assert all(read_epochs[0, "spatial_filter_cameras_cm_per_pixel"] == [0.3, 0.18])


### PR DESCRIPTION
Fix #19

@samuelbray32 Is this how a rectangular region should be defined? For the usage of `spatial_filter_region_node_coordinates_in_pixels`, are the coordinates of the last node supposed to equal the coordinates of the first node (so there should be num_nodes+1 coordinates in the list)? Or is it assumed that the polygon closes by connecting the last node to the first node, like I set up in the test here?