### PR TITLE
Prepare 0.2.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for ndx-franklab-novela
 
+## 0.2.4 (January 16, 2026)
+
+- Updated `ndx-optogenetics` dependency to version 0.3.0 and minimum `pynwb` dependency to version 3.1.3.
+
 ## 0.2.3 (September 22, 2025)
 
 - Pinned `ndx-optogenetics` dependency to version 0.2.0.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, NovelaNeurotechnologies, Loren Frank, Eric Denovellis, Ryan Ly
+Copyright (c) 2026, NovelaNeurotechnologies, Loren Frank, Eric Denovellis, Ryan Ly
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ Representation of a camera device in NWB.
 **Attributes:**
 
 - **meters_per_pixel**  `float`: meters per pixel
-- **model**  `string`: model of this camera device
 - **lens**  `string`: info about lens in this camera
 - **camera_name**  `string`: name of this camera
 - **frame_rate**  `float`: frame rate of this camera (optional)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,11 +7,11 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'ndx-franklab-novela'
-copyright = '2025, NovelaNeurotechnologies, Loren Frank, Eric Denovellis, Ryan Ly'
+copyright = '2026, NovelaNeurotechnologies, Loren Frank, Eric Denovellis, Ryan Ly'
 author = 'NovelaNeurotechnologies, Loren Frank, Eric Denovellis, Ryan Ly'
 
-version = '0.2.3'
-release = '0.2.3'
+version = '0.2.4'
+release = '0.2.4'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ndx-franklab-novela"
-version = "0.2.3"
+version = "0.2.4"
 authors = [
     { name="NovelaNeurotechnologies", email="devops@novelaneuro.com" },
     { name="Loren Frank", email="loren.frank@ucsf.edu" },

--- a/spec/ndx-franklab-novela.namespace.yaml
+++ b/spec/ndx-franklab-novela.namespace.yaml
@@ -16,4 +16,4 @@ namespaces:
   - namespace: core
   - namespace: ndx-optogenetics
   - source: ndx-franklab-novela.extensions.yaml
-  version: 0.2.3
+  version: 0.2.4

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -15,7 +15,7 @@ def main():
     # these arguments were auto-generated from your cookiecutter inputs
     ns_builder = NWBNamespaceBuilder(
         name="""ndx-franklab-novela""",
-        version="""0.2.3""",
+        version="""0.2.4""",
         doc="""NWB extension to store additional metadata and data types for Loren Frank's Lab""",
         author=[
             "NovelaNeurotechnologies",


### PR DESCRIPTION
- Bumped version to 0.2.4
- Removed `CameraDevice.model` from README
- Updated copyright date